### PR TITLE
Add helper to update to client status

### DIFF
--- a/amiqus/api.py
+++ b/amiqus/api.py
@@ -83,3 +83,16 @@ def post(href: str, *, data: dict, version: int = 2) -> dict:
             timeout=DEFAULT_REQUESTS_TIMEOUT,
         )
     )
+
+
+def patch(href: str, *, data: dict, version: int = 2) -> dict:
+    """Make a PATCH request and return the response as JSON."""
+    logger.debug("Amiqus API PATCH request: %s", href)
+    return _respond(
+        requests.patch(
+            _url(href, version),
+            headers=_headers(),
+            json=data,
+            timeout=DEFAULT_REQUESTS_TIMEOUT,
+        )
+    )

--- a/amiqus/helpers.py
+++ b/amiqus/helpers.py
@@ -4,7 +4,7 @@ from typing import Any, Union, Literal
 
 from django.conf import settings
 
-from .api import post, get
+from .api import post, get, patch
 from .models import Client, Record, Review, Event
 
 
@@ -91,3 +91,11 @@ def create_or_update_reviews(
                     review.parse(review_data).save()
             except Review.DoesNotExist:
                 Review(step=step).parse(review_data).save()
+
+
+def update_client_status(client: Client, client_status: Client.ClientStatus) -> None:
+    """Update the status of a client."""
+    response = patch(
+        f"clients/{client.amiqus_id}", data={"status": client_status.value}
+    )
+    client.parse(response).save()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from django.test import TestCase
 
-from amiqus.api import ApiError, _headers, _respond, _url, get, post
+from amiqus.api import ApiError, _headers, _respond, _url, get, post, patch
 from amiqus.settings import DEFAULT_REQUESTS_TIMEOUT
 
 
@@ -53,6 +53,23 @@ class ApiTests(TestCase):
         self.assertEqual(post("/", data=data), response.json.return_value)
         mock_post.assert_called_once_with(
             _url("/", 1),
+            headers=headers,
+            json=data,
+            timeout=DEFAULT_REQUESTS_TIMEOUT,
+        )
+
+    @mock.patch("requests.patch")
+    @mock.patch("amiqus.api._headers")
+    def test_patch(self, mock_headers, mock_patch):
+        """Test the patch function calls API correctly."""
+        response = mock.Mock()
+        response.status_code = 200
+        headers = mock_headers.return_value
+        data = {"foo": "bar"}
+        mock_patch.return_value = response
+        self.assertEqual(patch("/", data=data), response.json.return_value)
+        mock_patch.assert_called_once_with(
+            _url("/", 2),  # Note: Using API version 2 as specified in the function
             headers=headers,
             json=data,
             timeout=DEFAULT_REQUESTS_TIMEOUT,


### PR DESCRIPTION
Add a new helper `update_client_status` and a new API function `patch` to allow changing a `Client`'s status in Amiqus.

This is needed because the v2 API [removed](https://developers.amiqus.co/guides/migration-guides/requests-checks-forms.html#create-a-request) the `reset_client_status` preference from the `create_record` endpoint. This would automatically reset a **existing** client's status to "Requires review" when a new request is created for them.

We now need to do this ourselves upon record re-creation, and this can be done using these functions.