### PR TITLE
Misc: Trigger "record.reviewed" signal after Review objects creation

### DIFF
--- a/amiqus/views.py
+++ b/amiqus/views.py
@@ -67,10 +67,10 @@ def status_update(request: HttpRequest) -> HttpResponse:  # noqa: C901
         # Send signal for record.reviewed events
         if alias == "record.reviewed":
             logger.debug("Sending record_reviewed signal for record %s", resource.id)
+            create_or_update_reviews(event)
             record_reviewed.send(
                 sender=resource.__class__, record=resource, event=event, data=data
             )
-            create_or_update_reviews(event)
 
         if LOG_EVENTS:
             event.save()


### PR DESCRIPTION
New Review objects are created during record review. We should ensure the "record.reviewed" signal is triggered only after these objects are created in the database, as any signal handling code may depend on their existence.