### PR TITLE
Add a helper function to update `expired_at` value for a Record

### DIFF
--- a/amiqus/helpers.py
+++ b/amiqus/helpers.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, Union, Literal
+from datetime import datetime
+from typing import Any, Literal, Union
 
 from django.conf import settings
 
-from .api import post, get, patch
-from .models import Client, Record, Review, Event
+from .api import get, patch, post
+from .models import Client, Event, Record, Review
 
 
 def create_client(user: settings.AUTH_USER_MODEL, **kwargs: Any) -> Client:
@@ -99,3 +100,17 @@ def update_client_status(client: Client, client_status: Client.ClientStatus) -> 
         f"clients/{client.amiqus_id}", data={"status": client_status.value}
     )
     client.parse(response).save()
+
+
+def update_record_expired_at_date(record: Record, expired_at: datetime) -> None:
+    """
+    Update the expired_at date of a record.
+
+    The expired_at date determines the date by which the client needs to complete
+    the required checks. Updating it with a future date will extend this deadline.
+    """
+    response = patch(
+        f"records/{record.amiqus_id}",
+        data={"expired_at": expired_at.strftime("%Y-%m-%dT%H:%M:%SZ")}
+    )
+    record.parse(response).save()

--- a/amiqus/helpers.py
+++ b/amiqus/helpers.py
@@ -111,6 +111,6 @@ def update_record_expired_at_date(record: Record, expired_at: datetime) -> None:
     """
     response = patch(
         f"records/{record.amiqus_id}",
-        data={"expired_at": expired_at.strftime("%Y-%m-%dT%H:%M:%SZ")}
+        data={"expired_at": expired_at.strftime("%Y-%m-%dT%H:%M:%SZ")},
     )
     record.parse(response).save()

--- a/amiqus/helpers.py
+++ b/amiqus/helpers.py
@@ -108,6 +108,7 @@ def update_record_expired_at_date(record: Record, expired_at: datetime) -> None:
 
     The expired_at date determines the date by which the client needs to complete
     the required checks. Updating it with a future date will extend this deadline.
+    Value for expiry date must be within 10 days from now.
     """
     response = patch(
         f"records/{record.amiqus_id}",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,7 @@ TEST_RECORD = {
     "created_at": "2022-05-22T08:22:12Z",
     "updated_at": "2022-05-22T08:22:12Z",
     "archived_at": None,
+    "expired_at": "2022-06-01T08:22:12Z",
 }
 # record returned by the v2 API
 # WRONG - THIS IS THE V1 RESPONSE
@@ -173,6 +174,7 @@ TEST_RECORD_V2 = {
     "created_at": "2023-04-06T15:09:25Z",
     "updated_at": "2023-04-06T15:17:50Z",
     "archived_at": None,
+    "expired_at": "2022-06-01T08:22:12Z",
 }
 
 TEST_CHECK_PHOTO_ID = {

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,9 +1,14 @@
+from datetime import datetime
 from unittest import mock
 
 import pytest
 from dateutil.parser import parse as date_parse
 
-from amiqus.helpers import create_client, update_client_status
+from amiqus.helpers import (
+    create_client,
+    update_client_status,
+    update_record_expired_at_date,
+)
 from amiqus.models import Client
 
 
@@ -72,3 +77,16 @@ class TestUpdateClientStatus:
         )
         assert client.amiqus_id == str(client_data["id"])
         assert client.created_at == date_parse(client_data["created_at"])
+
+
+@pytest.mark.django_db
+class TestUpdateRecordExpiredAtDate:
+    @mock.patch("amiqus.helpers.patch")
+    def test_update_record_expired_at_date(self, mock_patch, record_data, record):
+        """Test the update_record_expired_at_date function."""
+        mock_patch.return_value = record_data
+        update_record_expired_at_date(record, datetime(2022, 6, 10))
+        mock_patch.assert_called_once_with(
+            f"records/{record.amiqus_id}",
+            data={"expired_at": "2022-06-10T00:00:00Z"},
+        )


### PR DESCRIPTION
Add a helper function to update the `expired_at` value for a Record.

This is required to support extending a Record's expiration so that the `perform_url` can be restored - this is a frequent use case where the clients have not completed the required checks within the given 10 days, and we want to update the expiration date to extend it instead of having to create a whole new Record.