### PR TITLE
Store blank 'perform_url' when records have no perform URL

### DIFF
--- a/amiqus/models/record.py
+++ b/amiqus/models/record.py
@@ -24,13 +24,14 @@ class RecordQuerySet(BaseQuerySet):
         logger.debug("Creating new Amiqus record from JSON: %s", raw)
 
         # Create the base record
+        perform_url = raw.get("perform_url") or ""
         record = Record.objects.create(
             user=client.user,
             client=client,
             amiqus_id=raw["id"],
             status=raw["status"],
             created_at=date_parse(raw["created_at"]),
-            perform_url=raw.get("perform_url"),
+            perform_url=perform_url,
             raw=raw,
         )
 

--- a/tests/test_models/test_record.py
+++ b/tests/test_models/test_record.py
@@ -81,6 +81,13 @@ class TestRecordManager:
         record = Record.objects.create_record(client=client, raw=data)
         assert record.checks.count() == 0
 
+    def test_create_record_with_no_perform_url(self, user, client):
+        """Test record creation works when perform_url is not returned from Amiqus."""
+        data = copy.deepcopy(TEST_RECORD)
+        data["perform_url"] = False
+        record = Record.objects.create_record(client=client, raw=data)
+        assert record.perform_url == ""
+
 
 @pytest.mark.django_db
 class TestRecordModel:


### PR DESCRIPTION
Some steps do not require freelancer interaction, so the API will return boolean `False` instead of a string perform URL when creating new records (e.g.: watchlist checks).

The `create_record` functions is not taking care of these cases, though, as it stores a stringified `"False"` instead of an empty string. This PR updates the function to ensure empty strings are stored in the database for such cases.