### PR TITLE
Add Django 6.0 and Python 3.13 support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,10 +22,10 @@ jobs:
             - name: Check out the repository
               uses: actions/checkout@v4
 
-            - name: Set up Python (3.11)
+            - name: Set up Python (3.12)
               uses: actions/setup-python@v4
               with:
-                  python-version: "3.11"
+                  python-version: "3.12"
 
             - name: Install and run tox
               run: |
@@ -45,10 +45,10 @@ jobs:
             - name: Check out the repository
               uses: actions/checkout@v4
 
-            - name: Set up Python (3.11)
+            - name: Set up Python (3.12)
               uses: actions/setup-python@v4
               with:
-                  python-version: "3.11"
+                  python-version: "3.12"
 
             - name: Install and run tox
               run: |
@@ -60,17 +60,8 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python: ["3.10", "3.11", "3.12", "3.13"]
-                django: ["42", "50", "51", "52", "main"]
-                exclude:
-                    - python: "3.10"
-                      django: "main"
-                    - python: "3.11"
-                      django: "main"
-                    - python: "3.13"
-                      django: "42"
-                    - python: "3.13"
-                      django: "50"
+                python: ["3.12", "3.13"]
+                django: ["52", "60", "main"]
 
         env:
             TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Django app for integration with the Amiqus API.
 
-The current version supports Django 4.2+ and Python 3.10+.
+The current version supports Django 5.2-6.0 and Python 3.12+.
 
 ## Background
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-amiqus"
-version = "0.4"
+version = "0.5"
 description = "Django app for integration with Amiqus."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -13,15 +13,11 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
-    "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
@@ -30,8 +26,8 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.10"
-django = "^4.2 || ^5.0"
+python = "^3.12"
+django = ">=5.2,<7.0"
 python-dateutil = "*"
 requests =  "*"
 simplejson = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,8 @@ envlist =
     fmt, lint, mypy,
     django-checks,
     ; https://docs.djangoproject.com/en/5.2/releases/
-    django42-py{310,311,312}
-    django50-py{310,311,312}
-    django51-py{311,312,313}
-    django52-py{311,312,313}
+    django52-py{312,313}
+    django60-py{312,313}
     djangomain-py{312,313}
 
 [testenv]
@@ -16,10 +14,8 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django42: Django>=4.2,<4.3
-    django50: Django>=5.0,<5.1
-    django51: Django>=5.1,<5.2
     django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =


### PR DESCRIPTION
## Summary

This PR upgrades the package to support Django 6.0 and Python 3.13.

## Changes

### Added
  - ✅ Django 6.0 support
  - ✅ Python 3.12, 3.13 support

### Removed
  - ❌ Python 3.9, 3.10, 3.11 support (now requires Python 3.12+)
  - ❌ Django 4.2 and 5.0 support (now supports Django 5.2-6.0)